### PR TITLE
Shipshape CI conformance: SHA-pin workflows, +github-actions Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: ivoronin/github-workflows/.github/workflows/release.yml@main
+    uses: ivoronin/github-workflows/.github/workflows/release.yml@da9a532c23890a7b70f130239a0abc93a268cdbe # main
     with:
       language: go
       docker: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,6 @@ on:
   pull_request:
 jobs:
   test:
-    uses: ivoronin/github-workflows/.github/workflows/test.yml@main
+    uses: ivoronin/github-workflows/.github/workflows/test.yml@da9a532c23890a7b70f130239a0abc93a268cdbe # main
     with:
       language: go


### PR DESCRIPTION
SHA-pin the github-workflows reusable calls (`@<sha> # main`) and add the `github-actions` Dependabot ecosystem. Repo settings (auto-merge off, security updates) handled separately.